### PR TITLE
Shorthand declaration and initialization of err

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	// Send Notification
-	_, err = webpush.SendNotification([]byte("Test"), &s, &webpush.Options{
+	_, err := webpush.SendNotification([]byte("Test"), &s, &webpush.Options{
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
 		TTL:             60,
 		VAPIDPrivateKey: vapidPrivateKey,


### PR DESCRIPTION
Great package!
However, the sample code in the README throws an error as `err` wasn't defined in the first place.