### PR TITLE
Add urgency and topic optional headers

### DIFF
--- a/webpush.go
+++ b/webpush.go
@@ -40,6 +40,8 @@ type Options struct {
 	HTTPClient      HTTPClient // Will replace with *http.Client by default if not included
 	Subscriber      string     // Sub in VAPID JWT token
 	TTL             int        // Set the TTL on the endpoint POST request
+	Urgency         string     // Set the Urgency header to change a message priority (Optional)
+	Topic           string     // Set the Topic header to collapse a pending messages (Optional)
 	VAPIDPrivateKey string     // Used to sign VAPID JWT token
 }
 
@@ -151,6 +153,13 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 	req.Header.Set("Content-Encoding", "aesgcm")
 	req.Header.Set("TTL", strconv.Itoa(options.TTL))
 
+	if isValidUrgency(options.Urgency) {
+		req.Header.Set("Urgency", options.Urgency)
+	}
+	if len(options.Topic) > 0 {
+		req.Header.Set("Topic", options.Topic)
+	}
+
 	// Set VAPID headers
 	err = vapid(req, s, options)
 	if err != nil {
@@ -222,4 +231,12 @@ func getInfo(infoType, clientPublicKey, serverPublicKey []byte) []byte {
 	info.Write(getKeyInfo(serverPublicKey))
 
 	return info.Bytes()
+}
+
+func isValidUrgency(urgency string) bool {
+	switch urgency {
+	case "very-low", "low", "normal", "high":
+		return true
+	}
+	return false
 }

--- a/webpush_test.go
+++ b/webpush_test.go
@@ -28,7 +28,9 @@ func TestSendNotification(t *testing.T) {
 
 	resp, err := SendNotification([]byte("Test"), getTestSubscription(), &Options{
 		HTTPClient:      &testHTTPClient{},
+		Urgency:         "low",
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
+		Topic:           "test_topic",
 		TTL:             0,
 		VAPIDPrivateKey: "testKey",
 	})

--- a/webpush_test.go
+++ b/webpush_test.go
@@ -28,10 +28,10 @@ func TestSendNotification(t *testing.T) {
 
 	resp, err := SendNotification([]byte("Test"), getTestSubscription(), &Options{
 		HTTPClient:      &testHTTPClient{},
-		Urgency:         "low",
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
 		Topic:           "test_topic",
 		TTL:             0,
+		Urgency:         "low",
 		VAPIDPrivateKey: "testKey",
 	})
 


### PR DESCRIPTION
```
Topic (Optional)

Topics are strings that can be used to replace a pending messages with a new message if they have matching topic names.
This is useful in scenarios where multiple messages are sent while a device is offline, and you really only want a user to see the latest message when the device is turned on.

Urgency (Optional)

Urgency indicates to the push service how important a message is to the user. This can be used by the push service to help conserve the battery life of a user's device by only waking up for important messages when battery is low.
The header value is defined as shown below. The default value is normal.

Urgency: <very-low | low | normal | high>
```

https://developers.google.com/web/fundamentals/push-notifications/web-push-protocol