### PR TITLE
Re-Export HTTP Client

### DIFF
--- a/webpush_test.go
+++ b/webpush_test.go
@@ -33,7 +33,7 @@ func getStandardEncodedTestSubscription() *Subscription {
 
 func TestSendNotificationToURLEncodedSubscription(t *testing.T) {
 	resp, err := SendNotification([]byte("Test"), getURLEncodedTestSubscription(), &Options{
-		httpClient:      &testHTTPClient{},
+		HTTPClient:      &testHTTPClient{},
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
 		Topic:           "test_topic",
 		TTL:             0,
@@ -56,7 +56,7 @@ func TestSendNotificationToURLEncodedSubscription(t *testing.T) {
 
 func TestSendNotificationToStandardEncodedSubscription(t *testing.T) {
 	resp, err := SendNotification([]byte("Test"), getStandardEncodedTestSubscription(), &Options{
-		httpClient:      &testHTTPClient{},
+		HTTPClient:      &testHTTPClient{},
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
 		Topic:           "test_topic",
 		TTL:             0,


### PR DESCRIPTION
Fixes https://github.com/SherClockHolmes/webpush-go/issues/18.

Re-exporting the HTTP client interface.