### PR TITLE
do not export Urgency type, due to exported constants

### DIFF
--- a/urgency.go
+++ b/urgency.go
@@ -1,26 +1,17 @@
 package webpush
 
-// Urgency indicates to the push service how important a message is to the user.
+// urgency indicates to the push service how important a message is to the user.
 // This can be used by the push service to help conserve the battery life of a user's device
 // by only waking up for important messages when battery is low.
-type Urgency string
+type urgency string
 
 const (
 	// UrgencyVeryLow requires device state: on power and Wi-Fi
-	UrgencyVeryLow Urgency = "very-low"
+	UrgencyVeryLow urgency = "very-low"
 	// UrgencyLow requires device state: on either power or Wi-Fi
-	UrgencyLow Urgency = "low"
+	UrgencyLow urgency = "low"
 	// UrgencyNormal excludes device state: low battery
-	UrgencyNormal Urgency = "normal"
+	UrgencyNormal urgency = "normal"
 	// UrgencyHigh admits device state: low battery
-	UrgencyHigh Urgency = "high"
+	UrgencyHigh urgency = "high"
 )
-
-// Checking allowable values for the urgency header
-func isValidUrgency(urgency Urgency) bool {
-	switch urgency {
-	case UrgencyVeryLow, UrgencyLow, UrgencyNormal, UrgencyHigh:
-		return true
-	}
-	return false
-}

--- a/webpush.go
+++ b/webpush.go
@@ -183,6 +183,8 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 		req.Header.Set("Topic", options.Topic)
 	}
 
+	req.Header.Set("Urgency", string(options.Urgency))
+
 	// Get VAPID Authorization header
 	vapidAuthHeader, err := getVAPIDAuthorizationHeader(
 		s.Endpoint,

--- a/webpush.go
+++ b/webpush.go
@@ -183,7 +183,9 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 		req.Header.Set("Topic", options.Topic)
 	}
 
-	req.Header.Set("Urgency", string(options.Urgency))
+	if options.Urgency != "" {
+		req.Header.Set("Urgency", string(options.Urgency))
+	}
 
 	// Get VAPID Authorization header
 	vapidAuthHeader, err := getVAPIDAuthorizationHeader(

--- a/webpush.go
+++ b/webpush.go
@@ -46,7 +46,7 @@ type Options struct {
 	Subscriber      string  // Sub in VAPID JWT token
 	Topic           string  // Set the Topic header to collapse a pending messages (Optional)
 	TTL             int     // Set the TTL on the endpoint POST request
-	Urgency         Urgency // Set the Urgency header to change a message priority (Optional)
+	Urgency         urgency // Set the urgency header to change a message priority (Optional)
 	VAPIDPublicKey  string  // VAPID public key, passed in VAPID Authorization header
 	VAPIDPrivateKey string  // VAPID private key, used to sign VAPID JWT token
 }
@@ -181,10 +181,6 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 	// Сheck the optional headers
 	if len(options.Topic) > 0 {
 		req.Header.Set("Topic", options.Topic)
-	}
-
-	if isValidUrgency(options.Urgency) {
-		req.Header.Set("Urgency", string(options.Urgency))
 	}
 
 	// Get VAPID Authorization header


### PR DESCRIPTION
Due to urgency has typed constants that is exported, we do not need to export `urgency`, so we don't need to validate them. 

This is draft pull request because it can breaks backward compatibility, if someone uses `Options` in such way:

```
opts := &webpush.Options{
    Urgency: webpush.Urgency("normal"),
}
```

If this library has guarantee of backward compatibility, better to merge this PR with a next major release. 