### PR TITLE
Fix private key base64 decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
 	json.Unmarshal([]byte("<YOUR_SUBSCRIPTION>"), s)
 
 	// Send Notification
-	_, err := webpush.SendNotification([]byte("Test"), s, &webpush.Options{
+	resp, err := webpush.SendNotification([]byte("Test"), s, &webpush.Options{
 		Subscriber:      "example@example.com",
 		VAPIDPublicKey:  "<YOUR_VAPID_PUBLIC_KEY>",
 		VAPIDPrivateKey: "<YOUR_VAPID_PRIVATE_KEY>",
@@ -37,6 +37,7 @@ func main() {
 	if err != nil {
 		// TODO: Handle error
 	}
+	defer resp.Body.Close()
 }
 ```
 

--- a/example/main.go
+++ b/example/main.go
@@ -18,7 +18,7 @@ func main() {
 	json.Unmarshal([]byte(subscription), s)
 
 	// Send Notification
-	_, err := webpush.SendNotification([]byte("Test"), s, &webpush.Options{
+	resp, err := webpush.SendNotification([]byte("Test"), s, &webpush.Options{
 		Subscriber:      "example@example.com", // Do not include "mailto:"
 		VAPIDPublicKey:  vapidPublicKey,
 		VAPIDPrivateKey: vapidPrivateKey,
@@ -27,4 +27,5 @@ func main() {
 	if err != nil {
 		// TODO: Handle error
 	}
+	defer resp.Body.Close()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
 )
+
+go 1.13

--- a/vapid.go
+++ b/vapid.go
@@ -77,8 +77,8 @@ func getVAPIDAuthorizationHeader(
 		"sub": fmt.Sprintf("mailto:%s", subscriber),
 	})
 
-	// Decode the vapid private key (base64)
-	decodedVapidPrivateKey, err := decodeVapidPrivateKey(vapidPrivateKey)
+	// Decode the VAPID private key
+	decodedVapidPrivateKey, err := decodeVapidKey(vapidPrivateKey)
 	if err != nil {
 		return "", err
 	}
@@ -91,16 +91,22 @@ func getVAPIDAuthorizationHeader(
 		return "", err
 	}
 
+	// Decode the VAPID public key
+	pubKey, err := decodeVapidKey(vapidPublicKey)
+	if err != nil {
+		return "", err
+	}
+
 	return fmt.Sprintf(
 		"vapid t=%s, k=%s",
 		jwtString,
-		vapidPublicKey,
+		base64.RawURLEncoding.EncodeToString(pubKey),
 	), nil
 }
 
 // Need to decode the vapid private key in multiple base64 formats
 // Solution from: https://github.com/SherClockHolmes/webpush-go/issues/29
-func decodeVapidPrivateKey(key string) ([]byte, error) {
+func decodeVapidKey(key string) ([]byte, error) {
 	bytes, err := base64.URLEncoding.DecodeString(key)
 	if err == nil {
 		return bytes, nil

--- a/vapid.go
+++ b/vapid.go
@@ -77,8 +77,8 @@ func getVAPIDAuthorizationHeader(
 		"sub": fmt.Sprintf("mailto:%s", subscriber),
 	})
 
-	// ECDSA
-	decodedVapidPrivateKey, err := base64.RawURLEncoding.DecodeString(vapidPrivateKey)
+	// Decode the vapid private key (base64)
+	decodedVapidPrivateKey, err := decodeVapidPrivateKey(vapidPrivateKey)
 	if err != nil {
 		return "", err
 	}
@@ -96,4 +96,15 @@ func getVAPIDAuthorizationHeader(
 		jwtString,
 		vapidPublicKey,
 	), nil
+}
+
+// Need to decode the vapid private key in multiple base64 formats
+// Solution from: https://github.com/SherClockHolmes/webpush-go/issues/29
+func decodeVapidPrivateKey(key string) ([]byte, error) {
+	bytes, err := base64.URLEncoding.DecodeString(key)
+	if err == nil {
+		return bytes, nil
+	}
+
+	return base64.RawURLEncoding.DecodeString(key)
 }

--- a/webpush.go
+++ b/webpush.go
@@ -229,6 +229,7 @@ func decodeSubscriptionKey(key string) ([]byte, error) {
 	if err == nil {
 		return bytes, nil
 	}
+
 	return base64.URLEncoding.DecodeString(buf.String())
 }
 


### PR DESCRIPTION
Fixes https://github.com/SherClockHolmes/webpush-go/issues/26
Fixes https://github.com/SherClockHolmes/webpush-go/issues/29

- Added the base64 decode method from #29 (@froodian).
- Updated example and README to remind users to close the response body.
