### PR TITLE
Fix #27: Panic on large notification payloads

### DIFF
--- a/webpush_test.go
+++ b/webpush_test.go
@@ -2,6 +2,7 @@ package webpush
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -74,5 +75,19 @@ func TestSendNotificationToStandardEncodedSubscription(t *testing.T) {
 			resp.StatusCode,
 			201,
 		)
+	}
+}
+
+func TestSendTooLargeNotification(t *testing.T) {
+	_, err := SendNotification([]byte(strings.Repeat("Test", int(MaxRecordSize))), getStandardEncodedTestSubscription(), &Options{
+		HTTPClient:      &testHTTPClient{},
+		Subscriber:      "<EMAIL@EXAMPLE.COM>",
+		Topic:           "test_topic",
+		TTL:             0,
+		Urgency:         "low",
+		VAPIDPrivateKey: "testKey",
+	})
+	if err == nil {
+		t.Fatal("Expected error with too large payload")
 	}
 }


### PR DESCRIPTION
This commit fixes a case where, with large notification payloads, `pad`
would call make with a negative length, triggering a panic.