### PR TITLE
ECDH output on P-256 curve must be always 32 bytes

### DIFF
--- a/webpush.go
+++ b/webpush.go
@@ -95,14 +95,20 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 
 	localPublicKey := elliptic.Marshal(curve, x, y)
 
-	// Combine application keys with dh
+	// Combine application keys with receiver's EC public key
 	sharedX, sharedY := elliptic.Unmarshal(curve, dh)
 	if sharedX == nil {
 		return nil, errors.New("Unmarshal Error: Public key is not a valid point on the curve")
 	}
 
-	sx, _ := curve.ScalarMult(sharedX, sharedY, localPrivateKey)
-	sharedECDHSecret := sx.Bytes()
+	// Derive ECDH shared secret
+	sx, sy := curve.ScalarMult(sharedX, sharedY, localPrivateKey)
+	if !curve.IsOnCurve(sx, sy) {
+		return nil, errors.New("Encryption error: ECDH shared secret isn't on curve")
+	}
+	mlen := curve.Params().BitSize / 8
+	sharedECDHSecret := make([]byte, mlen)
+	sx.FillBytes(sharedECDHSecret)
 
 	hash := sha256.New
 


### PR DESCRIPTION
big.Int Bytes() returns dynamically length byte string, while SEC1 ECDH
procedure is defined to output a fixed length byte string (in big-endian).

> https://www.secg.org/sec1-v2.pdf
> SEC1: 6.1.3. Key Agreement Operation
> Action 2. Convert $$ z $$ to an octet string the conversion routine specified in Section 2.3.5.
>   Section 2.3.5. Field-Element-to-Octet-String Conversion
>     where $$ mlen = log_2q/8 $$
>     Section 2.3.7. Integer-to-Octet-String Conversion