### PR TITLE
Add ability to specify Vapid JWT token expiration

### DIFF
--- a/vapid.go
+++ b/vapid.go
@@ -64,6 +64,7 @@ func getVAPIDAuthorizationHeader(
 	subscriber,
 	vapidPublicKey,
 	vapidPrivateKey string,
+	expiration time.Time,
 ) (string, error) {
 	// Create the JWT token
 	subURL, err := url.Parse(endpoint)
@@ -73,7 +74,7 @@ func getVAPIDAuthorizationHeader(
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		"aud": fmt.Sprintf("%s://%s", subURL.Scheme, subURL.Host),
-		"exp": time.Now().Add(time.Hour * 12).Unix(),
+		"exp": expiration.Unix(),
 		"sub": fmt.Sprintf("mailto:%s", subscriber),
 	})
 

--- a/vapid_test.go
+++ b/vapid_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt"
 )
@@ -25,6 +26,7 @@ func TestVAPID(t *testing.T) {
 		sub,
 		vapidPublicKey,
 		vapidPrivateKey,
+		time.Now().Add(time.Hour*12),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We have a use-case to customize the expiration time for the vapid token. This adds this functionality in a backwards compatible fashion.