### PR TITLE
Use expiration parameter in getVAPIDAuthorizationHeader

### DIFF
--- a/vapid.go
+++ b/vapid.go
@@ -79,7 +79,7 @@ func getVAPIDAuthorizationHeader(
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		"aud": subURL.Scheme + "://" + subURL.Host,
-		"exp": time.Now().Add(time.Hour * 12).Unix(),
+		"exp": expiration.Unix(),
 		"sub": subscriber,
 	})
 

--- a/vapid_test.go
+++ b/vapid_test.go
@@ -20,13 +20,16 @@ func TestVAPID(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Unusual expiration to check that the expiration value is used
+	expiration := time.Now().Add(time.Hour * 11).Add(23 * time.Minute)
+
 	// Get authentication header
 	vapidAuthHeader, err := getVAPIDAuthorizationHeader(
 		s.Endpoint,
 		sub,
 		vapidPublicKey,
 		vapidPrivateKey,
-		time.Now().Add(time.Hour*12),
+		expiration,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +67,15 @@ func TestVAPID(t *testing.T) {
 
 		if claims["aud"] == "" {
 			t.Fatal("Audience should not be empty")
+		}
+
+		expectedExp := float64(expiration.Unix())
+		if expectedExp != claims["exp"] {
+			t.Fatalf(
+				"Incorrect exp, expected=%v, got=%v",
+				expectedExp,
+				claims["exp"],
+			)
 		}
 	} else {
 		t.Fatal(err)


### PR DESCRIPTION
In the current state of the repository, `expiration` was being ignored in `getVAPIDAuthorizationHeader`, and would always use a value based on 12 hours after time.Now().  This seems to be the result of a bad merge conflict resolution, as it was correct in #45 but the merge commit for #46 backed out the relevant change.

With this PR, expiration is now used as provided, reintroducing the behavior added in #45.  A test is also added to catch any potential future breakage here.

Fixes #73.