### PR TITLE
AuthScheme and improved example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/**
+vapid_keys.json
 
 .DS_Store
 *.out

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ func main() {
 }
 ```
 
+### Auth Scheme
+
+Due to inconsistencies in how different browsers have implemented the Web Push protocol, it is necessary to specify which VAPID authentication scheme to use.
+
+*   `vapid`: The original scheme, used by Firefox and other browsers.
+*   `webpush`: The modern scheme, used by Chrome.
+
+You can specify the scheme in the `Options` struct:
+
+```go
+&webpush.Options{
+    AuthScheme: webpush.WebPush,
+    // ... other options
+}
+```
+
+If no `AuthScheme` is specified, it will default to `vapid`.
+
 ### Generating VAPID Keys
 
 Use the helper method `GenerateVAPIDKeys` to generate the VAPID key pair.

--- a/example/README.md
+++ b/example/README.md
@@ -1,21 +1,37 @@
-# example
+# Example
 
-## Access index.html
+This example demonstrates how to use the `webpush-go` library to send push notifications.
 
-Replace the public VAPID key in index.html.
+## Running the Example
 
-Use a tool such as SimpleHTTPServer to run a web server:
+1.  **Start the server:**
 
-```
-python3 -m http.server 8000
-```
+    ```bash
+    go run main.go
+    ```
 
-Go to `http://localhost:8000` and copy the logged subsciption from the console.
+    The server will start on port 8080 and generate the VAPID keys.
 
-## Test send a notification
+2.  **Subscribe to notifications:**
 
-Replace the public/private VAPID keys. Use the subscription you had from the first section.
+    Open your browser and navigate to `http://localhost:8080`. The browser will ask for permission to show notifications. Click "Allow".
 
-```bash
-go run main.go
-```
+3.  **Send a test notification:**
+
+    Click the "Send Test Notification" button. You should receive a push notification in your browser.
+
+## How it Works
+
+*   The `main.go` file starts a web server that serves the `index.html` and `service-worker.js` files.
+*   When you visit `index.html`, the JavaScript code subscribes to push notifications and sends the subscription object to the server.
+*   The server stores the subscription in memory.
+*   When you click the "Send Test Notification" button, the browser sends a request to the server, which then uses the `webpush-go` library to send a notification to your browser.
+
+### Browser Compatibility
+
+The example has crude browser detection and sends the appropriate VAPID authentication scheme to the server.
+
+*   For Chrome, it uses the `webpush` scheme.
+*   For other browsers, it uses the `vapid` scheme.
+
+This is handled in the `index.html` file, where the browser is detected and the `authScheme` is sent to the server when a notification is requested. The `main.go` server then uses this `authScheme` to send the notification with the correct VAPID headers.

--- a/example/index.html
+++ b/example/index.html
@@ -4,24 +4,32 @@
   <meta charset="utf-8">
   <title>Webpush Golang Example</title>
 </head>
-<body>
+  <body style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh;">
+  <button id="send-notification-btn" disabled style="padding: 10px; font-size: 16px;">
+    Send Test Notification
+  </button>
+
   <script>
+    const sendNotificationBtn = document.getElementById('send-notification-btn');
+    let currentSubscription;
+
     function subscribe() {
+      console.log('Subscribing to push notifications...');
       navigator.serviceWorker.ready
         .then(function(registration) {
-          const vapidPublicKey = '<YOUR_VAPID_PUBLIC_KEY>';
-
-          return registration.pushManager.subscribe({
-            userVisibleOnly: true,
-            applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
-          });
+          console.log('Fetching VAPID public key...');
+          return fetch('/vapid_public_key').then(response => response.text()).then(vapidPublicKey => {
+            console.log('Got VAPID public key.');
+            return registration.pushManager.subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+            });
+          })
         })
         .then(function(subscription) {
-          console.log(
-            JSON.stringify({
-              subscription: subscription,
-            })
-          );
+          currentSubscription = subscription;
+          console.log('Subscription registered.');
+          sendNotificationBtn.disabled = false;
         })
         .catch(err => console.error(err));
     }
@@ -36,23 +44,45 @@
     }
 
     if ('serviceWorker' in navigator) {
+      console.log('Registering service worker...');
       navigator.serviceWorker.register('service-worker.js');
       navigator.serviceWorker.ready
         .then(function(registration) {
+          console.log('Service worker ready, checking for subscription...');
           return registration.pushManager.getSubscription();
         })
         .then(function(subscription) {
           if (!subscription) {
+            console.log('No subscription found, starting subscription process.');
             subscribe();
           } else {
-            console.log(
-              JSON.stringify({
-                subscription: subscription,
-              })
-            );
+            console.log('Existing subscription found.');
+            currentSubscription = subscription;
+            sendNotificationBtn.disabled = false;
           }
         });
     }
+
+    sendNotificationBtn.addEventListener('click', () => {
+      console.log('Sending notification...');
+
+      let authScheme = 'vapid';
+      const userAgent = navigator.userAgent;
+      if (userAgent.indexOf("Chrome") > -1 && userAgent.indexOf("Edg") === -1) {
+          authScheme = 'webpush';
+      }
+
+      fetch('/send_notification', {
+        method: 'POST',
+        body: JSON.stringify({
+          subscription: currentSubscription,
+          authScheme: authScheme,
+        })
+      })
+      .then(response => response.text())
+      .then(text => console.log('Server response:', text))
+      .catch(err => console.error('Error sending notification:', err));
+    });
   </script>
 </body>
 </html>

--- a/example/main.go
+++ b/example/main.go
@@ -2,30 +2,116 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 )
 
-const (
-	subscription    = ``
-	vapidPublicKey  = ""
-	vapidPrivateKey = ""
+var (
+	vapidPrivateKey string
+	vapidPublicKey  string
 )
 
-func main() {
-	// Decode subscription
-	s := &webpush.Subscription{}
-	json.Unmarshal([]byte(subscription), s)
+// VAPIDKeys holds the VAPID private and public keys.
+type VAPIDKeys struct {
+	PrivateKey string `json:"private_key"`
+	PublicKey  string `json:"public_key"`
+}
 
-	// Send Notification
-	resp, err := webpush.SendNotification([]byte("Test"), s, &webpush.Options{
-		Subscriber:      "example@example.com", // Do not include "mailto:"
-		VAPIDPublicKey:  vapidPublicKey,
-		VAPIDPrivateKey: vapidPrivateKey,
-		TTL:             30,
-	})
-	if err != nil {
-		// TODO: Handle error
+// SendNotificationRequest is the request body for the /send_notification endpoint.
+type SendNotificationRequest struct {
+	Subscription webpush.Subscription `json:"subscription"`
+	AuthScheme   webpush.AuthScheme   `json:"authScheme"`
+}
+
+
+func main() {
+	// Check for VAPID keys file
+	_, err := os.Stat("vapid_keys.json")
+	if os.IsNotExist(err) {
+		log.Println("VAPID keys file not found, generating new ones...")
+		newPrivateKey, newPublicKey, err := webpush.GenerateVAPIDKeys()
+		if err != nil {
+			log.Fatalf("Failed to generate VAPID keys: %v", err)
+		}
+		vapidPrivateKey = newPrivateKey
+		vapidPublicKey = newPublicKey
+
+		keys := VAPIDKeys{
+			PrivateKey: vapidPrivateKey,
+			PublicKey:  vapidPublicKey,
+		}
+		jsonBytes, err := json.Marshal(keys)
+		if err != nil {
+			log.Fatalf("Failed to marshal keys to JSON: %v", err)
+		}
+
+		if err := ioutil.WriteFile("vapid_keys.json", jsonBytes, 0600); err != nil {
+			log.Fatalf("Failed to save keys file: %v", err)
+		}
+		log.Println("New VAPID keys generated and saved.")
+	} else {
+		log.Println("Loading VAPID keys from file...")
+		jsonBytes, err := ioutil.ReadFile("vapid_keys.json")
+		if err != nil {
+			log.Fatalf("Failed to read keys file: %v", err)
+		}
+
+		var keys VAPIDKeys
+		if err := json.Unmarshal(jsonBytes, &keys); err != nil {
+			log.Fatalf("Failed to unmarshal keys from JSON: %v", err)
+		}
+		vapidPrivateKey = keys.PrivateKey
+		vapidPublicKey = keys.PublicKey
+		log.Println("VAPID keys loaded.")
 	}
-	defer resp.Body.Close()
+
+	http.HandleFunc("/vapid_public_key", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(vapidPublicKey))
+	})
+
+	http.HandleFunc("/send_notification", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Error reading body: %v", err)
+			http.Error(w, "Error reading body", http.StatusInternalServerError)
+			return
+		}
+
+		var req SendNotificationRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			log.Printf("Error unmarshalling request: %v", err)
+			http.Error(w, "Error unmarshalling request", http.StatusBadRequest)
+			return
+		}
+		
+		// Send Notification
+		resp, err := webpush.SendNotification([]byte("Test"), &req.Subscription, &webpush.Options{
+			AuthScheme:      req.AuthScheme,
+			Subscriber:      "example@example.com", // Do not include "mailto:"
+			VAPIDPublicKey:  vapidPublicKey,
+			VAPIDPrivateKey: vapidPrivateKey,
+			TTL:             30,
+		})
+		if err != nil {
+			log.Printf("Error sending notification: %v", err)
+			http.Error(w, "Error sending notification", http.StatusInternalServerError)
+			return
+		}
+
+		defer resp.Body.Close()
+
+		// Print status code
+		fmt.Fprintf(w, "Status: %d", resp.StatusCode)
+	})
+
+	http.Handle("/", http.FileServer(http.Dir(".")))
+
+	log.Println("Server started on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/vapid.go
+++ b/vapid.go
@@ -13,6 +13,17 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// AuthScheme is the type for VAPID authentication schemes.
+type AuthScheme string
+
+const (
+	// Vapid is the original VAPID scheme.
+	Vapid AuthScheme = "vapid"
+	// WebPush is the modern VAPID scheme.
+	WebPush AuthScheme = "webpush"
+)
+
+
 // GenerateVAPIDKeys will create a private and public VAPID key pair
 func GenerateVAPIDKeys() (privateKey, publicKey string, err error) {
 	// Get the private key from the P256 curve
@@ -58,18 +69,20 @@ func generateVAPIDHeaderKeys(privateKey []byte) *ecdsa.PrivateKey {
 	}
 }
 
-// getVAPIDAuthorizationHeader
-func getVAPIDAuthorizationHeader(
+// generateVAPIDHeaders generates the VAPID headers.
+// It returns a map of headers.
+func generateVAPIDHeaders(
 	endpoint,
 	subscriber,
 	vapidPublicKey,
 	vapidPrivateKey string,
 	expiration time.Time,
-) (string, error) {
+	authScheme AuthScheme,
+) (map[string]string, error) {
 	// Create the JWT token
 	subURL, err := url.Parse(endpoint)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Unless subscriber is an HTTPS URL, assume an e-mail address
@@ -86,7 +99,7 @@ func getVAPIDAuthorizationHeader(
 	// Decode the VAPID private key
 	decodedVapidPrivateKey, err := decodeVapidKey(vapidPrivateKey)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	privKey := generateVAPIDHeaderKeys(decodedVapidPrivateKey)
@@ -94,16 +107,24 @@ func getVAPIDAuthorizationHeader(
 	// Sign token with private key
 	jwtString, err := token.SignedString(privKey)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// Decode the VAPID public key
-	pubKey, err := decodeVapidKey(vapidPublicKey)
-	if err != nil {
-		return "", err
+	headers := make(map[string]string)
+
+	switch authScheme {
+	case WebPush:
+		headers["Authorization"] = "WebPush " + jwtString
+		headers["Crypto-Key"] = "p256ecdsa=" + vapidPublicKey
+	default: // Default to the old scheme
+		pubKey, err := decodeVapidKey(vapidPublicKey)
+		if err != nil {
+			return nil, err
+		}
+		headers["Authorization"] = "vapid t=" + jwtString + ", k=" + base64.RawURLEncoding.EncodeToString(pubKey)
 	}
 
-	return "vapid t=" + jwtString + ", k=" + base64.RawURLEncoding.EncodeToString(pubKey), nil
+	return headers, nil
 }
 
 // Need to decode the vapid private key in multiple base64 formats

--- a/vapid_test.go
+++ b/vapid_test.go
@@ -23,64 +23,89 @@ func TestVAPID(t *testing.T) {
 	// Unusual expiration to check that the expiration value is used
 	expiration := time.Now().Add(time.Hour * 11).Add(23 * time.Minute)
 
-	// Get authentication header
-	vapidAuthHeader, err := getVAPIDAuthorizationHeader(
-		s.Endpoint,
-		sub,
-		vapidPublicKey,
-		vapidPrivateKey,
-		expiration,
-	)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		authScheme AuthScheme
+	}{
+		{Vapid},
+		{WebPush},
 	}
 
-	// Validate the token in the Authorization header
-	tokenString := getTokenFromAuthorizationHeader(vapidAuthHeader, t)
-
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
-			t.Fatal("Wrong validation method need ECDSA!")
-		}
-
-		// To decode the token it needs the VAPID public key
-		b64 := base64.RawURLEncoding
-		decodedVapidPrivateKey, err := b64.DecodeString(vapidPrivateKey)
+	for _, test := range tests {
+		// Get authentication header
+		vapidHeaders, err := generateVAPIDHeaders(
+			s.Endpoint,
+			sub,
+			vapidPublicKey,
+			vapidPrivateKey,
+			expiration,
+			test.authScheme,
+		)
 		if err != nil {
-			t.Fatal("Could not decode VAPID private key")
+			t.Fatal(err)
 		}
 
-		privKey := generateVAPIDHeaderKeys(decodedVapidPrivateKey)
-		return privKey.Public(), nil
-	})
+		// Validate the token in the Authorization header
+		tokenString := getTokenFromAuthorizationHeader(vapidHeaders["Authorization"], test.authScheme, t)
 
-	// Check the claims on the token
-	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		expectedSub := fmt.Sprintf("mailto:%s", sub)
-		if expectedSub != claims["sub"] {
-			t.Fatalf(
-				"Incorreect mailto, expected=%s, got=%s",
-				expectedSub,
-				claims["sub"],
-			)
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+				t.Fatal("Wrong validation method need ECDSA!")
+			}
+
+			// To decode the token it needs the VAPID public key
+			b64 := base64.RawURLEncoding
+			decodedVapidPrivateKey, err := b64.DecodeString(vapidPrivateKey)
+			if err != nil {
+				t.Fatal("Could not decode VAPID private key")
+			}
+
+			privKey := generateVAPIDHeaderKeys(decodedVapidPrivateKey)
+			return privKey.Public(), nil
+		})
+
+		// Check the claims on the token
+		if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+			expectedSub := fmt.Sprintf("mailto:%s", sub)
+			if expectedSub != claims["sub"] {
+				t.Fatalf(
+					"Incorreect mailto, expected=%s, got=%s",
+					expectedSub,
+					claims["sub"],
+				)
+			}
+
+			if claims["aud"] == "" {
+				t.Fatal("Audience should not be empty")
+			}
+
+			expectedExp := float64(expiration.Unix())
+			if expectedExp != claims["exp"] {
+				t.Fatalf(
+					"Incorrect exp, expected=%v, got=%v",
+					expectedExp,
+					claims["exp"],
+				)
+			}
+		} else {
+			t.Fatal(err)
 		}
 
-		if claims["aud"] == "" {
-			t.Fatal("Audience should not be empty")
+		// Check headers
+		switch test.authScheme {
+		case WebPush:
+			if vapidHeaders["Crypto-Key"] != "p256ecdsa="+vapidPublicKey {
+				t.Fatalf("Incorrect crypto key header, expected=%s, got=%s", "p256ecdsa="+vapidPublicKey, vapidHeaders["Crypto-Key"])
+			}
+		case Vapid:
+			pubKey, err := decodeVapidKey(vapidPublicKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(vapidHeaders["Authorization"], "k="+base64.RawURLEncoding.EncodeToString(pubKey)) {
+				t.Fatalf("Incorrect authorization header, expected to contain k=%s, got=%s", vapidPublicKey, vapidHeaders["Authorization"])
+			}
 		}
-
-		expectedExp := float64(expiration.Unix())
-		if expectedExp != claims["exp"] {
-			t.Fatalf(
-				"Incorrect exp, expected=%v, got=%v",
-				expectedExp,
-				claims["exp"],
-			)
-		}
-	} else {
-		t.Fatal(err)
 	}
-
 }
 
 func TestVAPIDKeys(t *testing.T) {
@@ -99,16 +124,30 @@ func TestVAPIDKeys(t *testing.T) {
 }
 
 // Helper function for extracting the token from the Authorization header
-func getTokenFromAuthorizationHeader(tokenHeader string, t *testing.T) string {
-	hsplit := strings.Split(tokenHeader, " ")
-	if len(hsplit) < 3 {
-		t.Fatal("Failed to auth split header")
-	}
+func getTokenFromAuthorizationHeader(tokenHeader string, authScheme AuthScheme, t *testing.T) string {
+	switch authScheme {
+	case WebPush:
+		hsplit := strings.Split(tokenHeader, " ")
+		if len(hsplit) != 2 {
+			t.Fatalf("Failed to auth split header, expected 2 parts, got %d", len(hsplit))
+		}
 
-	tsplit := strings.Split(hsplit[1], "=")
-	if len(tsplit) < 2 {
-		t.Fatal("Failed to t split header on =")
-	}
+		if hsplit[0] != "WebPush" {
+			t.Fatalf("Incorrect scheme, expected WebPush, got %s", hsplit[0])
+		}
 
-	return tsplit[1][:len(tsplit[1])-1]
+		return hsplit[1]
+	default: // Vapid
+		hsplit := strings.Split(tokenHeader, " ")
+		if len(hsplit) < 3 {
+			t.Fatal("Failed to auth split header")
+		}
+
+		tsplit := strings.Split(hsplit[1], "=")
+		if len(tsplit) < 2 {
+			t.Fatal("Failed to t split header on =")
+		}
+
+		return tsplit[1][:len(tsplit[1])-1]
+	}
 }

--- a/webpush.go
+++ b/webpush.go
@@ -42,6 +42,7 @@ type HTTPClient interface {
 
 // Options are config and extra params needed to send a notification
 type Options struct {
+	AuthScheme      AuthScheme // VAPID authentication scheme, defaults to "vapid"
 	HTTPClient      HTTPClient // Will replace with *http.Client by default if not included
 	RecordSize      uint32     // Limit the record size
 	Subscriber      string     // Sub in VAPID JWT token
@@ -220,19 +221,22 @@ func SendNotificationWithContext(ctx context.Context, message []byte, s *Subscri
 		expiration = time.Now().Add(time.Hour * 12)
 	}
 
-	// Get VAPID Authorization header
-	vapidAuthHeader, err := getVAPIDAuthorizationHeader(
+	// Get VAPID headers
+	vapidHeaders, err := generateVAPIDHeaders(
 		s.Endpoint,
 		options.Subscriber,
 		options.VAPIDPublicKey,
 		options.VAPIDPrivateKey,
 		expiration,
+		options.AuthScheme,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", vapidAuthHeader)
+	for key, value := range vapidHeaders {
+		req.Header.Set(key, value)
+	}
 
 	// Send the request
 	var client HTTPClient

--- a/webpush_test.go
+++ b/webpush_test.go
@@ -33,61 +33,93 @@ func getStandardEncodedTestSubscription() *Subscription {
 }
 
 func TestSendNotificationToURLEncodedSubscription(t *testing.T) {
-	resp, err := SendNotification([]byte("Test"), getURLEncodedTestSubscription(), &Options{
-		HTTPClient:      &testHTTPClient{},
-		RecordSize:      3070,
-		Subscriber:      "<EMAIL@EXAMPLE.COM>",
-		Topic:           "test_topic",
-		TTL:             0,
-		Urgency:         "low",
-		VAPIDPublicKey:  "test-public",
-		VAPIDPrivateKey: "test-private",
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		authScheme AuthScheme
+	}{
+		{Vapid},
+		{WebPush},
 	}
 
-	if resp.StatusCode != 201 {
-		t.Fatalf(
-			"Incorreect status code, expected=%d, got=%d",
-			resp.StatusCode,
-			201,
-		)
+	for _, test := range tests {
+		resp, err := SendNotification([]byte("Test"), getURLEncodedTestSubscription(), &Options{
+			HTTPClient:      &testHTTPClient{},
+			RecordSize:      3070,
+			Subscriber:      "<EMAIL@EXAMPLE.COM>",
+			Topic:           "test_topic",
+			TTL:             0,
+			Urgency:         "low",
+			VAPIDPublicKey:  "test-public",
+			VAPIDPrivateKey: "test-private",
+			AuthScheme:      test.authScheme,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != 201 {
+			t.Fatalf(
+				"Incorreect status code, expected=%d, got=%d",
+				resp.StatusCode,
+				201,
+			)
+		}
 	}
 }
 
 func TestSendNotificationToStandardEncodedSubscription(t *testing.T) {
-	resp, err := SendNotification([]byte("Test"), getStandardEncodedTestSubscription(), &Options{
-		HTTPClient:      &testHTTPClient{},
-		Subscriber:      "<EMAIL@EXAMPLE.COM>",
-		Topic:           "test_topic",
-		TTL:             0,
-		Urgency:         "low",
-		VAPIDPrivateKey: "testKey",
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		authScheme AuthScheme
+	}{
+		{Vapid},
+		{WebPush},
 	}
 
-	if resp.StatusCode != 201 {
-		t.Fatalf(
-			"Incorreect status code, expected=%d, got=%d",
-			resp.StatusCode,
-			201,
-		)
+	for _, test := range tests {
+		resp, err := SendNotification([]byte("Test"), getStandardEncodedTestSubscription(), &Options{
+			HTTPClient:      &testHTTPClient{},
+			Subscriber:      "<EMAIL@EXAMPLE.COM>",
+			Topic:           "test_topic",
+			TTL:             0,
+			Urgency:         "low",
+			VAPIDPublicKey:  "test-public",
+			VAPIDPrivateKey: "testKey",
+			AuthScheme:      test.authScheme,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != 201 {
+			t.Fatalf(
+				"Incorreect status code, expected=%d, got=%d",
+				resp.StatusCode,
+				201,
+			)
+		}
 	}
 }
 
 func TestSendTooLargeNotification(t *testing.T) {
-	_, err := SendNotification([]byte(strings.Repeat("Test", int(MaxRecordSize))), getStandardEncodedTestSubscription(), &Options{
-		HTTPClient:      &testHTTPClient{},
-		Subscriber:      "<EMAIL@EXAMPLE.COM>",
-		Topic:           "test_topic",
-		TTL:             0,
-		Urgency:         "low",
-		VAPIDPrivateKey: "testKey",
-	})
-	if err == nil {
-		t.Fatalf("Error is nil, expected=%s", ErrMaxPadExceeded)
+	tests := []struct {
+		authScheme AuthScheme
+	}{
+		{Vapid},
+		{WebPush},
+	}
+
+	for _, test := range tests {
+		_, err := SendNotification([]byte(strings.Repeat("Test", int(MaxRecordSize))), getStandardEncodedTestSubscription(), &Options{
+			HTTPClient:      &testHTTPClient{},
+			Subscriber:      "<EMAIL@EXAMPLE.COM>",
+			Topic:           "test_topic",
+			TTL:             0,
+			Urgency:         "low",
+			VAPIDPublicKey:  "test-public",
+			VAPIDPrivateKey: "testKey",
+			AuthScheme:      test.authScheme,
+		})
+		if err == nil {
+			t.Fatalf("Error is nil, expected=%s", ErrMaxPadExceeded)
+		}
 	}
 }


### PR DESCRIPTION
Fixes for https://github.com/SherClockHolmes/webpush-go/issues/82, https://github.com/SherClockHolmes/webpush-go/issues/72

Updated the library to support both the original and modern VAPID authentication schemes (`vapid` and `webpush`) to handle browser inconsistencies. A new `AuthScheme` option has been added to the `Options` struct to select the desired scheme, defaulting to `vapid`. The example application has also been updated to handle the management for vapid keys automatically.

